### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt


### PR DESCRIPTION
Include missing files in sdist for #1

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.WAUbdluTNK
+ trap 'rm -rf /tmp/tmp.WAUbdluTNK' EXIT
+ python -m venv /tmp/tmp.WAUbdluTNK
+ python setup.py sdist -d /tmp/tmp.WAUbdluTNK
running sdist
running egg_info
writing label_studio_evalme.egg-info/PKG-INFO
writing dependency_links to label_studio_evalme.egg-info/dependency_links.txt
writing requirements to label_studio_evalme.egg-info/requires.txt
writing top-level names to label_studio_evalme.egg-info/top_level.txt
reading manifest file 'label_studio_evalme.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'label_studio_evalme.egg-info/SOURCES.txt'
running check
creating label-studio-evalme-0.0.5
creating label-studio-evalme-0.0.5/evalme
creating label-studio-evalme-0.0.5/evalme/image
creating label-studio-evalme-0.0.5/evalme/text
creating label-studio-evalme-0.0.5/label_studio_evalme.egg-info
copying files to label-studio-evalme-0.0.5...
copying MANIFEST.in -> label-studio-evalme-0.0.5
copying README.md -> label-studio-evalme-0.0.5
copying requirements.txt -> label-studio-evalme-0.0.5
copying setup.py -> label-studio-evalme-0.0.5
copying evalme/__init__.py -> label-studio-evalme-0.0.5/evalme
copying evalme/classification.py -> label-studio-evalme-0.0.5/evalme
copying evalme/eval_item.py -> label-studio-evalme-0.0.5/evalme
copying evalme/utils.py -> label-studio-evalme-0.0.5/evalme
copying evalme/image/__init__.py -> label-studio-evalme-0.0.5/evalme/image
copying evalme/image/object_detection.py -> label-studio-evalme-0.0.5/evalme/image
copying evalme/text/__init__.py -> label-studio-evalme-0.0.5/evalme/text
copying evalme/text/text.py -> label-studio-evalme-0.0.5/evalme/text
copying label_studio_evalme.egg-info/PKG-INFO -> label-studio-evalme-0.0.5/label_studio_evalme.egg-info
copying label_studio_evalme.egg-info/SOURCES.txt -> label-studio-evalme-0.0.5/label_studio_evalme.egg-info
copying label_studio_evalme.egg-info/dependency_links.txt -> label-studio-evalme-0.0.5/label_studio_evalme.egg-info
copying label_studio_evalme.egg-info/requires.txt -> label-studio-evalme-0.0.5/label_studio_evalme.egg-info
copying label_studio_evalme.egg-info/top_level.txt -> label-studio-evalme-0.0.5/label_studio_evalme.egg-info
Writing label-studio-evalme-0.0.5/setup.cfg
Creating tar archive
removing 'label-studio-evalme-0.0.5' (and everything under it)
+ cd /
+ /tmp/tmp.WAUbdluTNK/bin/pip install /tmp/tmp.WAUbdluTNK/label-studio-evalme-0.0.5.tar.gz
Processing /tmp/tmp.WAUbdluTNK/label-studio-evalme-0.0.5.tar.gz
Collecting Shapely==1.6.4.post2 (from label-studio-evalme==0.0.5)
  Downloading https://files.pythonhosted.org/packages/a2/fb/7a7af9ef7a35d16fa23b127abee272cfc483ca89029b73e92e93cdf36e6b/Shapely-1.6.4.post2.tar.gz (225kB)
Collecting textdistance==4.1.5 (from label-studio-evalme==0.0.5)
  Downloading https://files.pythonhosted.org/packages/3f/18/31397b687f50ffae65469175f07faa68f288e27fcd8716276004c42e5637/textdistance-4.1.5-py3-none-any.whl
Installing collected packages: Shapely, textdistance, label-studio-evalme
  Running setup.py install for Shapely: started
    Running setup.py install for Shapely: finished with status 'done'
  Running setup.py install for label-studio-evalme: started
    Running setup.py install for label-studio-evalme: finished with status 'done'
Successfully installed Shapely-1.6.4.post2 label-studio-evalme-0.0.5 textdistance-4.1.5
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.WAUbdluTNK
```
